### PR TITLE
Use new Ansible hcloud features

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,13 +2,20 @@
 
 Ansible Playbook that will create a Rancher Master and a defined count of workers.
 
-Before you start make sure to create the group_vars/servers.yml from the server.yaml.example file.
+Before you start make sure to create the `group_vars/servers.yml` from the `server.yaml.example` file.
 
 To run this, you need to do something like this:
 
+## Requirements
+
+* Install Ansible 2.8 or newer
+* Install hcloud Python module (`pip install hcloud-python`)
+* Enable hcloud inventory in Ansible configuration (explained [here](https://docs.ansible.com/ansible/latest/plugins/inventory.html))
+
+## Usage
+
 ```
 export HCLOUD_TOKEN=hetzner-token-goes-here
-ansible-playbook -i $(which hcloud_inventory) site.yml
+ansible-playbook -i hcloud.yml site.yml
 ```
 
-It also depends on [hcloud-hetzner](https://github.com/thetechnick/hcloud-ansible)

--- a/hcloud.yml
+++ b/hcloud.yml
@@ -1,0 +1,1 @@
+plugin: hcloud

--- a/roles/servers/tasks/main.yml
+++ b/roles/servers/tasks/main.yml
@@ -14,14 +14,15 @@
 
 - module_defaults:
     hcloud_server:
-      token: "{{ lookup('env','HCLOUD_TOKEN') | default(hetzner_token, true) }}"
+      api_token: "{{ lookup('env','HCLOUD_TOKEN') | default(hetzner_token, true) }}"
       image: "{{ hetzner_instance_os }}"
       server_type: "{{ hetzner_instance_type }}"
       datacenter: "{{ hetzner_datacenter }}"
       ssh_keys: "{{ hetzner_ssh_keys }}"
   block:
-    - hcloud_server:
-        name: "{{ kubemaster + workernames }}"
+    - loop: "{{ kubemaster + workernames }}"
+      hcloud_server:
+        name: "{{ item }}"
 
 - pause:
     seconds: 60


### PR DESCRIPTION
Ansible 2.8 added official support for hcloud_server and hcloud inventory. We can use these instead of the abandoned hcloud-ansible project.